### PR TITLE
Add NFC read history functionality

### DIFF
--- a/nfc-tool-maniifest-v1/ContentView.swift
+++ b/nfc-tool-maniifest-v1/ContentView.swift
@@ -1,21 +1,39 @@
-//
-//  ContentView.swift
-//  nfc-tool-maniifest-v1
-//
-//  Created by DOE PESCI on 2/20/25.
-//
-
 import SwiftUI
 
 struct ContentView: View {
+    @State private var showingHistory = false
+
     var body: some View {
         VStack {
             Image(systemName: "globe")
                 .imageScale(.large)
                 .foregroundStyle(.tint)
             Text("Hello, world!")
+            Button(action: {
+                showingHistory = true
+            }) {
+                Text("View NFC Read History")
+            }
+            .padding()
+            .sheet(isPresented: $showingHistory) {
+                NFCReadHistoryView()
+            }
         }
         .padding()
+    }
+}
+
+struct NFCReadHistoryView: View {
+    var body: some View {
+        List(NFCReadHistory.retrieveAll()) { history in
+            VStack(alignment: .leading) {
+                Text("Serial Number: \(history.serialNumber)")
+                Text("Type: \(history.type)")
+                Text("Tech: \(history.tech)")
+                Text("Payload: \(history.payload)")
+                Text("Date: \(history.date)")
+            }
+        }
     }
 }
 

--- a/nfc-tool-maniifest-v1/NFCReadHistory.swift
+++ b/nfc-tool-maniifest-v1/NFCReadHistory.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+struct NFCReadHistory: Codable {
+    var id: UUID
+    var date: Date
+    var serialNumber: String
+    var type: String
+    var tech: String
+    var payload: String
+
+    static let userDefaultsKey = "NFCReadHistory"
+
+    static func save(_ history: NFCReadHistory) {
+        var histories = retrieveAll()
+        histories.append(history)
+        if let data = try? JSONEncoder().encode(histories) {
+            UserDefaults.standard.set(data, forKey: userDefaultsKey)
+        }
+    }
+
+    static func retrieveAll() -> [NFCReadHistory] {
+        if let data = UserDefaults.standard.data(forKey: userDefaultsKey),
+           let histories = try? JSONDecoder().decode([NFCReadHistory].self, from: data) {
+            return histories
+        }
+        return []
+    }
+}

--- a/nfc-tool-maniifest-v1/nfc_tool_maniifest_v1App.swift
+++ b/nfc-tool-maniifest-v1/nfc_tool_maniifest_v1App.swift
@@ -1,14 +1,9 @@
-//
-//  nfc_tool_maniifest_v1App.swift
-//  nfc-tool-maniifest-v1
-//
-//  Created by DOE PESCI on 2/20/25.
-//
-
 import SwiftUI
 
 @main
 struct nfc_tool_maniifest_v1App: App {
+    var nfcReadHistory = NFCReadHistory()
+
     var body: some Scene {
         WindowGroup {
             ContentView()


### PR DESCRIPTION
Implement NFC read history saving functionality.

* **NFCReadHistory.swift**: Add a new file to define the `NFCReadHistory` struct. Implement methods to save and retrieve NFC read data using UserDefaults.
* **ContentView.swift**: Add a button to view saved NFC read history. Update the `VStack` to include the new button. Implement a new view to display the saved NFC read history.
* **nfc_tool_maniifest_v1App.swift**: Initialize NFC read history functionality in the `nfc_tool_maniifest_v1App` struct. Add a reference to the `NFCReadHistory` struct.

